### PR TITLE
Fix pip install in docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,5 +21,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install -r requirements.txt
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
Changes from `pip install mkdocs-material` to `pip install -r requirements.txt` in CI docs build job.