### PR TITLE
Docs: Fix issue #33 - [DOC NEW] Documentation page for Intelligent Code Commenter (ICC)

### DIFF
--- a/docs/intelligent-code-commenter.md
+++ b/docs/intelligent-code-commenter.md
@@ -1,0 +1,30 @@
+# Intelligent Code Commenter (ICC)
+
+## Overview
+The Intelligent Code Commenter (ICC) is a new product designed to help developers by automatically generating meaningful comments for their code. This document provides a guide on how to get started with ICC.
+
+## Getting Started
+This section outlines the steps to quickly set up and use the Intelligent Code Commenter.
+
+### Prerequisites
+*(Details to be filled from product documentation: IDE compatibility, language support, any necessary accounts or licenses)*
+
+### Installation
+*(Details to be filled from product documentation: How to install ICC (e.g., plugin, CLI tool), configuration steps)*
+
+### Basic Usage
+*(Details to be filled from product documentation)*
+
+1.  **Open your project:** How to activate ICC within a project.
+2.  **Select code for commenting:** How to specify which code segments need comments.
+3.  **Generate comments:** The command or action to trigger comment generation.
+4.  **Review and apply:** How to review suggested comments and apply them to the codebase.
+
+## Advanced Features
+*(Details to be filled from product documentation: Customization options, integration with version control, batch commenting)*
+
+## Troubleshooting
+*(Details to be filled from product documentation: Common issues and solutions, how to get support)*
+
+---
+*Note: This page is a placeholder. The content needs to be populated based on the "Product Specification-Intelligent Code Commenter (ICC).md", "PRD-Intelligent Code Commenter (ICC).md", "Design Document-Intelligent Code Commenter (ICC).md", and "Configuration Doc-Intelligent Code Commenter (ICC).md" documents referenced in GitHub issue #33.*


### PR DESCRIPTION
This PR addresses issue #33 by creating a new documentation page `docs/intelligent-code-commenter.md` for the Intelligent Code Commenter (ICC). It includes placeholder content that needs to be filled in based on the product's specification and design documents.