### PR TITLE
Docs: Fix issue #33 - [DOC NEW] Documentation page for Intelligent Code Commenter (ICC)

### DIFF
--- a/docs/intelligent-code-commenter.md
+++ b/docs/intelligent-code-commenter.md
@@ -1,0 +1,26 @@
+# Intelligent Code Commenter (ICC)
+
+Welcome to the documentation for the Intelligent Code Commenter (ICC)! This guide will help you get started.
+
+## Overview
+The Intelligent Code Commenter (ICC) is a new product designed to help developers by automatically generating meaningful comments for their code. This page is targeted towards mid-level developers.
+
+## Getting Started
+To get started with ICC, please follow these steps:
+1.  **Installation**: [Details on how to install or access ICC - *to be filled from Product Specification/Configuration Doc mentioned in issue #33*]
+2.  **Configuration**: [Details on configuring ICC for your project - *to be filled from Configuration Doc mentioned in issue #33*]
+3.  **Usage**: [Basic usage instructions and examples - *to be filled from Design Document/Product Specification mentioned in issue #33*]
+
+## Key Features
+-   [Feature 1 - *to be filled from PRD/Product Specification mentioned in issue #33*]
+-   [Feature 2 - *to be filled from PRD/Product Specification mentioned in issue #33*]
+-   [Feature 3 - *to be filled from PRD/Product Specification mentioned in issue #33*]
+
+## Further Information
+For more detailed information, please refer to the following documents (linked in issue #33) which should be used to populate this page:
+-   Product Specification-Intelligent Code Commenter (ICC).md
+-   PRD-Intelligent Code Commenter (ICC).md
+-   Design Document-Intelligent Code Commenter (ICC).md
+-   Configuration Doc-Intelligent Code Commenter (ICC).md
+
+*(Note: The content of this page is a placeholder and needs to be populated based on the linked attachment documents from GitHub issue #33.)*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -98,6 +98,7 @@ nav:
     - Gemini Models Overview: 'model-reference/gemini.md'
     - Imagen Models Overview: 'image/Imagen-on-Vertex-AI.md'
     - Code Models Overview: 'code/code-models-overview.md'
+    - Intelligent Code Commenter: 'intelligent-code-commenter.md'
     - Open Models (Gemma, Llama): 'open-models/Use-Gemma-open-models.md' # Representative
     - Partner Models (Claude, AI21): 'partner-models/use-partner-models.md'
     - Introduction to Prompting: 'learn/prompts/Introduction-to-prompting.md'


### PR DESCRIPTION
This PR addresses issue #33 by adding a placeholder documentation page for the Intelligent Code Commenter (docs/intelligent-code-commenter.md) and updating mkdocs.yml to include it in the navigation. The content of the new page is a placeholder and needs to be populated based on the attachments in issue #33, as I cannot access external URLs to fetch their content.