### PR TITLE
Docs: Fix issue #41 - Create documentation for Express Mode with API Key

### DIFF
--- a/docs/learn/express-mode-api-key.md
+++ b/docs/learn/express-mode-api-key.md
@@ -1,0 +1,40 @@
+# Express Mode with API Key Authentication
+
+Express Mode offers a streamlined, high-performance way to interact with our services. When combined with API Key authentication, it provides a secure and efficient method for programmatic access, ideal for automated workflows and integrations.
+
+## What is Express Mode?
+
+Express Mode is an optimized pathway for API requests, designed for scenarios where speed and low latency are critical. It bypasses some of the standard processing steps, leading to faster response times. This mode is particularly beneficial for high-volume applications.
+
+## Using API Keys with Express Mode
+
+API Key authentication is the recommended method for securing Express Mode access. It ensures that only authorized clients can utilize this high-speed pathway.
+
+### Key Benefits:
+
+*   **Enhanced Performance:** Significantly reduces latency for API requests.
+*   **Secure Access:** Leverages robust API key authentication to protect your resources.
+*   **Scalability:** Ideal for applications requiring high throughput and rapid responses.
+*   **Simplified Integration:** Easy to implement in your existing client applications.
+
+## How to Enable and Use Express Mode
+
+1.  **Obtain an API Key:** If you don't already have one, generate an API key from your account dashboard. Ensure the key has the necessary permissions for the services you intend to access via Express Mode.
+2.  **Construct Your Request:** When making an API call, include your API key in the request headers. For example:
+    ```
+    Authorization: Bearer YOUR_API_KEY
+    ```
+3.  **Specify Express Mode Endpoint (if applicable):** Some services might require a specific endpoint or a parameter to enable Express Mode. Refer to the specific API documentation for the service you are using.
+    *Example:*
+    If a service uses a query parameter: `https://api.example.com/data?mode=express`
+    If a service uses a specific header: `X-Execution-Mode: express`
+
+    *(Note: The exact method to invoke Express Mode can vary. Always consult the relevant API endpoint documentation.)*
+
+## Best Practices
+
+*   **Secure Your API Key:** Treat your API key like a password. Do not embed it directly in client-side code or commit it to version control. Use environment variables or secure secret management solutions.
+*   **Monitor Usage:** Keep track of your API usage through the dashboard to understand your consumption patterns and costs associated with Express Mode.
+*   **Refer to Specific API Docs:** While this guide provides a general overview, always consult the detailed documentation for the specific API service you are using with Express Mode for precise implementation details.
+
+By leveraging Express Mode with API Key authentication, you can significantly enhance the performance and security of your application's interactions with our services.


### PR DESCRIPTION
This PR addresses issue #41 by creating new documentation for Express Mode with API Key authentication in `docs/learn/express-mode-api-key.md`.