### PR TITLE
Docs: Add new document for Agent Framework Kit (issue #47)

### DIFF
--- a/docs/agent-framework-kit.md
+++ b/docs/agent-framework-kit.md
@@ -1,0 +1,172 @@
+# Agent Framework Kit
+
+## Introduction
+
+The Agent Framework Kit (AFK) provides a flexible and powerful environment for building, managing, and deploying autonomous agents. These agents can perform a wide variety of tasks, from simple automation to complex decision-making processes. AFK is designed to be extensible, allowing developers to create custom agents tailored to their specific needs. This document provides an overview of how to construct a generic agent within the AFK and demonstrates a practical example of an agent that evaluates code.
+
+## Core Concepts
+
+Before diving into agent construction, let's understand a few core concepts:
+
+*   **Agent**: An autonomous entity that can perceive its environment, make decisions, and take actions to achieve specific goals.
+*   **Skill**: A reusable component that defines a specific capability or action an agent can perform. For example, reading a file, calling an API, or executing code.
+*   **Tool**: An external resource or utility that an agent can leverage, often accessed via a Skill. Examples include code linters, APIs, or databases.
+*   **Environment**: The context in which an agent operates. This can include file systems, network connections, or simulated worlds.
+*   **Task**: A specific objective or set of objectives assigned to an agent.
+
+## Constructing a Generic Agent
+
+Constructing a generic agent in AFK typically involves the following steps:
+
+1.  **Define Agent Purpose**: Clearly state what the agent is supposed to achieve. This will guide the selection and development of its skills and tools.
+2.  **Identify Required Skills**: Based on the purpose, list the capabilities the agent needs. Will it need to read files, understand natural language, interact with web services, or execute code?
+3.  **Select or Develop Tools**: Choose existing tools or develop new ones that the agent's skills will utilize. For instance, a code evaluation agent might use a linting library as a tool.
+4.  **Implement Agent Logic**: Write the core logic of the agent that orchestrates its skills to perform tasks. This usually involves a loop where the agent perceives, decides, and acts.
+5.  **Configure the Agent**: Set up the agent with its skills, tools, and any necessary configuration parameters (e.g., API keys, file paths).
+
+## Code Evaluation Agent Example
+
+Let's create a Python-based agent that can evaluate code. This agent will be designed to perform simple checks on a given Python code snippet, such as identifying the presence of "TODO" comments or "print" statements.
+
+### 1. Agent Purpose
+
+The purpose of this `CodeEvaluationAgent` is to analyze Python code snippets and report findings based on predefined rules (e.g., find TODOs, print statements).
+
+### 2. Required Skills
+
+*   `CodeAnalysisSkill`: To parse and inspect the code.
+*   `ReportingSkill`: To present the findings.
+
+### 3. Tools
+
+*   For this example, we'll keep it simple and use Python's built-in string manipulation and `ast` (Abstract Syntax Tree) module as part of the `CodeAnalysisSkill` rather than an external tool. For more complex scenarios, tools like `pylint` or `flake8` could be integrated.
+
+### 4. Agent Logic and Implementation (Python Pseudocode)
+
+Here's a conceptual Python example of how such an agent might be structured within a hypothetical AFK.
+
+```python
+import ast
+
+class CodeAnalysisSkill:
+    """A skill to analyze Python code."""
+
+    def find_todos(self, code_snippet: str) -> list[str]:
+        """Finds all TODO comments in the code."""
+        todos = []
+        for i, line in enumerate(code_snippet.splitlines()):
+            if "TODO" in line:
+                todos.append(f"Line {i+1}: {line.strip()}")
+        return todos
+
+    def find_print_statements(self, code_snippet: str) -> list[str]:
+        """Finds all print statements using AST."""
+        print_statements = []
+        try:
+            tree = ast.parse(code_snippet)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == 'print':
+                    # In a real scenario, you'd want to get the line number from the AST node
+                    # For simplicity, we're not extracting exact line content here via AST
+                    print_statements.append(f"Print statement found (details require line number mapping from AST node: {ast.dump(node)})")
+        except SyntaxError as e:
+            print_statements.append(f"Syntax error in code: {e}")
+        return print_statements
+
+class ReportingSkill:
+    """A skill to report findings."""
+
+    def format_report(self, findings: dict) -> str:
+        report = "Code Evaluation Report:\n"
+        if not findings:
+            return report + "No specific issues found based on current checks."
+        for key, value in findings.items():
+            if value:
+                report += f"\n--- {key} ---\n"
+                for item in value:
+                    report += f"- {item}\n"
+        return report
+
+class CodeEvaluationAgent:
+    """
+    A generic agent designed to evaluate code snippets.
+    """
+    def __init__(self):
+        self.analysis_skill = CodeAnalysisSkill()
+        self.reporting_skill = ReportingSkill()
+        self.name = "CodeEvaluator_v1"
+        print(f"Agent '{self.name}' initialized.")
+
+    def evaluate(self, code_snippet: str) -> str:
+        """
+        Evaluates the given code snippet using its skills.
+        Args:
+            code_snippet: A string containing the Python code to evaluate.
+        Returns:
+            A string containing the evaluation report.
+        """
+        print(f"Agent '{self.name}' starting evaluation...")
+        findings = {}
+
+        # Perform analyses
+        findings["TODOs"] = self.analysis_skill.find_todos(code_snippet)
+        findings["Print Statements"] = self.analysis_skill.find_print_statements(code_snippet)
+        
+        # Add more analyses as needed, e.g.:
+        # findings["Security Vulnerabilities"] = self.security_analysis_skill.check_vulnerabilities(code_snippet)
+        # findings["Performance Bottlenecks"] = self.performance_skill.check_inefficiencies(code_snippet)
+
+        report = self.reporting_skill.format_report(findings)
+        print(f"Agent '{self.name}' evaluation complete.")
+        return report
+
+# --- Example Usage ---
+if __name__ == "__main__":
+    # This part is for demonstrating the agent, not part of the agent framework itself.
+    
+    sample_code = '''
+# This is a sample Python script.
+
+def hello_world():
+    # TODO: Add more robust error handling
+    print("Hello, world!") # A print statement here
+
+class MyClass:
+    def __init__(self, name):
+        self.name = name
+        # TODO: Initialize other properties
+
+    def greet(self):
+        # Another print, for testing
+        print(f"Hello, {self.name}!")
+        # TODO: Implement actual greeting logic
+'''
+
+    eval_agent = CodeEvaluationAgent()
+    evaluation_report = eval_agent.evaluate(sample_code)
+    print("\n--- Final Report ---")
+    print(evaluation_report)
+
+    empty_code = "pass # No issues here"
+    evaluation_report_empty = eval_agent.evaluate(empty_code)
+    print("\n--- Final Report for Empty Code ---")
+    print(evaluation_report_empty)
+```
+
+### 5. Configuration and Execution
+
+In a real AFK environment:
+
+*   The `CodeEvaluationAgent` class, along with its skills, would be registered with the framework.
+*   Tasks would be dispatched to the agent, perhaps with code passed as a string or a reference to a file.
+*   The agent's `evaluate` method would be invoked by the framework when it receives a task.
+
+This example provides a basic structure. A production-ready agent within AFK would likely have more sophisticated error handling, logging, configuration management (e.g., for enabling/disabling specific checks), and integration with other agents or systems.
+
+## Next Steps
+
+*   Explore how to integrate external linters or static analysis tools as `Tools` within AFK.
+*   Learn about deploying agents and managing their lifecycle.
+*   Investigate how agents can collaborate or be chained together to perform more complex workflows.
+
+This document serves as a starting point for understanding and building agents with the Agent Framework Kit. As you delve deeper, refer to specific AFK API documentation and examples for more advanced features.


### PR DESCRIPTION
This PR introduces a new document for the Agent Framework Kit as requested in issue #47. It covers an introduction to AFK, how to construct a generic agent, and provides a Python code sample for an agent that evaluates code.